### PR TITLE
Fix: move custom events registration to module scope

### DIFF
--- a/src/key_watcher/key_watcher.js
+++ b/src/key_watcher/key_watcher.js
@@ -1,14 +1,15 @@
 import { CorePlugin, Events, Log, version } from '@clappr/core'
 import { KeyMap } from '../keys_mapping/map'
 
+Events.register('CORE_SMART_TV_KEY_PRESSED')
+Events.register('CONTAINER_SMART_TV_KEY_PRESSED')
+
 export default class TVsKeyMappingPlugin extends CorePlugin {
   get name() { return 'tvs_key_mapping' }
 
   get supportedVersion() { return { min: version } }
 
   constructor(core) {
-    Events.register('CORE_SMART_TV_KEY_PRESSED')
-    Events.register('CONTAINER_SMART_TV_KEY_PRESSED')
     super(core)
     this.start = this.start.bind(this)
     this.stop = this.stop.bind(this)


### PR DESCRIPTION
As of now, the registration of custom events (e.g., `CORE_SMART_TV_KEY_PRESSED` and `CONTAINER_SMART_TV_KEY_PRESSED`) is done in the constructor of the plugin. This causes a subtle bug where other plugins that need to listen to these events must be loaded afterwards, otherwise these events will not exist at the moment Clappr bind the events to them.

Moving the registration to the module scope fixes this issue since custom events are registered as soon as the module is imported, regardless of in which order a user register his/her plugins.